### PR TITLE
Change Material-top-tabs to ScrollView

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -16,7 +16,6 @@
     "@expo-google-fonts/inter": "^0.1.0",
     "@expo/vector-icons": "^10.0.0",
     "@react-native-community/masked-view": "0.1.10",
-    "@react-navigation/material-top-tabs": "^5.3.10",
     "@react-navigation/native": "^5.0.9",
     "@react-navigation/stack": "^5.1.1",
     "axios": "^0.21.0",

--- a/mobile/src/components/Text/index.tsx
+++ b/mobile/src/components/Text/index.tsx
@@ -1,12 +1,12 @@
 import React, { PropsWithChildren } from 'react';
-import { TextProps as ReactNativeTextProps } from 'react-native';
+import { Animated, TextProps as RNTextProps } from 'react-native';
 
 import { Theme } from '../../styles/styled';
 import theme from '../../styles/theme';
 
 import { Container } from './styles';
 
-export type TextProps = ReactNativeTextProps & {
+export type TextProps = Animated.AnimatedProps<RNTextProps> & {
   variant?: keyof Theme['textVariantes'];
   color?: keyof Theme['colors'];
   bold?: boolean;

--- a/mobile/src/pages/Pokemon/PokemonDetails/About/index.tsx
+++ b/mobile/src/pages/Pokemon/PokemonDetails/About/index.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import { Foundation as Icon } from '@expo/vector-icons';
 
-import { TabProps } from '../tabs';
+import { SlideProps } from '../tabs';
 import Text from '../../../../components/Text';
 import {
   convertValues,
@@ -19,7 +19,7 @@ import {
   ShadowContainer,
 } from './styles';
 
-const About = ({ pokemon }: TabProps) => {
+const About = ({ pokemon }: SlideProps) => {
   const pokemonFormatted = useMemo(() => {
     return {
       ...pokemon,

--- a/mobile/src/pages/Pokemon/PokemonDetails/BaseStats/index.tsx
+++ b/mobile/src/pages/Pokemon/PokemonDetails/BaseStats/index.tsx
@@ -3,12 +3,12 @@ import { useFocusEffect } from '@react-navigation/native';
 import { Animated } from 'react-native';
 
 import Text from '../../../../components/Text';
-import { TabProps } from '../tabs';
+import { SlideProps } from '../tabs';
 
 import Effectiveness from './Effectiveness';
 import { Stat, StatGraph, StatLine, StatValue } from './styles';
 
-const BaseStats = ({ pokemon }: TabProps) => {
+const BaseStats = ({ pokemon }: SlideProps) => {
   const translateX = useMemo(() => new Animated.Value(-1), []);
 
   useFocusEffect(() =>

--- a/mobile/src/pages/Pokemon/PokemonDetails/Evolution/index.tsx
+++ b/mobile/src/pages/Pokemon/PokemonDetails/Evolution/index.tsx
@@ -4,12 +4,12 @@ import { ActivityIndicator } from 'react-native';
 import Text from '../../../../components/Text';
 import api from '../../../../services/api';
 import { EvolutionChain } from '../../../../types';
-import { TabProps } from '../tabs';
+import { SlideProps } from '../tabs';
 
 import EvolutionSection from './EvolutionSection';
 import { Content } from './styles';
 
-const Evolution = ({ pokemon }: TabProps) => {
+const Evolution = ({ pokemon }: SlideProps) => {
   const [evolutions, setEvolutions] = useState({} as EvolutionChain);
   const [loading, setLoading] = useState(true);
 

--- a/mobile/src/pages/Pokemon/PokemonDetails/index.tsx
+++ b/mobile/src/pages/Pokemon/PokemonDetails/index.tsx
@@ -1,11 +1,12 @@
-import React, { useCallback, useRef, useState, useMemo } from 'react';
+import React, { useCallback, useRef, useMemo } from 'react';
 import { Animated, Dimensions, ScrollView } from 'react-native';
+import { useTheme } from 'styled-components';
 
 import { POKEMON_SUMMARY_HEIGHT } from '../../../constants';
 import { Pokemon } from '../../../types';
 import Text from '../../../components/Text';
 
-import { tabs } from './tabs';
+import { tabs, TAB_BUTTON_WIDTH } from './tabs';
 import {
   Container,
   Tabs,
@@ -21,23 +22,19 @@ type PokemonDetailsProps = {
 
 const { width } = Dimensions.get('window');
 
-export const TAB_BUTTON_WIDTH = (width - 48) / 4;
-
 const PokemonDetails = ({ pokemon, translateY }: PokemonDetailsProps) => {
-  const scrollViewRef = useRef<ScrollView>(null);
+  const { colors } = useTheme();
 
-  const [currentIndex, setCurrentIndex] = useState(0);
+  const scrollViewRef = useRef<ScrollView>(null);
 
   const translateX = useMemo(() => new Animated.Value(0), []);
 
-  const handleChangeTab = useCallback((index: number) => {
+  const handleChangeSlide = useCallback((index: number) => {
     if (scrollViewRef.current) {
       scrollViewRef.current.scrollTo({
         x: width * index,
         animated: true,
       });
-
-      setCurrentIndex(index);
     }
   }, []);
 
@@ -51,7 +48,7 @@ const PokemonDetails = ({ pokemon, translateY }: PokemonDetailsProps) => {
         },
       },
     ],
-    { useNativeDriver: true },
+    { useNativeDriver: false },
   );
 
   const containerStyle = {
@@ -82,11 +79,21 @@ const PokemonDetails = ({ pokemon, translateY }: PokemonDetailsProps) => {
     <Container style={containerStyle}>
       <Tabs>
         {tabs.map((tab, index) => {
-          const isSelected = index === currentIndex;
+          const inputRange = [
+            (index - 1) * width,
+            index * width,
+            (index + 1) * width,
+          ];
+
+          const color = translateX.interpolate({
+            inputRange,
+            outputRange: [colors.grey, colors.black, colors.grey],
+            extrapolate: 'clamp',
+          });
 
           return (
-            <TabButton key={index} onPress={() => handleChangeTab(index)}>
-              <Text color={isSelected ? 'black' : 'grey'} bold={isSelected}>
+            <TabButton key={index} onPress={() => handleChangeSlide(index)}>
+              <Text bold style={{ color }}>
                 {tab.name}
               </Text>
             </TabButton>

--- a/mobile/src/pages/Pokemon/PokemonDetails/index.tsx
+++ b/mobile/src/pages/Pokemon/PokemonDetails/index.tsx
@@ -1,24 +1,58 @@
-import React from 'react';
-import { Animated } from 'react-native';
-import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
-import { useTheme } from 'styled-components';
+import React, { useCallback, useRef, useState, useMemo } from 'react';
+import { Animated, Dimensions, ScrollView } from 'react-native';
 
 import { POKEMON_SUMMARY_HEIGHT } from '../../../constants';
 import { Pokemon } from '../../../types';
 import Text from '../../../components/Text';
 
-import tabs from './tabs';
-import { Container, TabWrapper } from './styles';
-
-const Tab = createMaterialTopTabNavigator();
+import { tabs } from './tabs';
+import {
+  Container,
+  Tabs,
+  TabButton,
+  SelectedIndicator,
+  SlideWrapper,
+} from './styles';
 
 type PokemonDetailsProps = {
   translateY: Animated.Value;
   pokemon: Pokemon;
 };
 
+const { width } = Dimensions.get('window');
+
+export const TAB_BUTTON_WIDTH = (width - 48) / 4;
+
 const PokemonDetails = ({ pokemon, translateY }: PokemonDetailsProps) => {
-  const { colors } = useTheme();
+  const scrollViewRef = useRef<ScrollView>(null);
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const translateX = useMemo(() => new Animated.Value(0), []);
+
+  const handleChangeTab = useCallback((index: number) => {
+    if (scrollViewRef.current) {
+      scrollViewRef.current.scrollTo({
+        x: width * index,
+        animated: true,
+      });
+
+      setCurrentIndex(index);
+    }
+  }, []);
+
+  const onScroll = Animated.event(
+    [
+      {
+        nativeEvent: {
+          contentOffset: {
+            x: translateX,
+          },
+        },
+      },
+    ],
+    { useNativeDriver: true },
+  );
 
   const containerStyle = {
     transform: [
@@ -32,47 +66,51 @@ const PokemonDetails = ({ pokemon, translateY }: PokemonDetailsProps) => {
     ],
   };
 
+  const selectedIndicatorStyle = {
+    transform: [
+      {
+        translateX: translateX.interpolate({
+          inputRange: tabs.map((_, index) => width * index),
+          outputRange: tabs.map((_, index) => TAB_BUTTON_WIDTH * index),
+          extrapolate: 'clamp',
+        }),
+      },
+    ],
+  };
+
   return (
     <Container style={containerStyle}>
-      <Tab.Navigator
-        backBehavior="none"
-        tabBarOptions={{
-          indicatorStyle: {
-            backgroundColor: colors.blue,
-          },
-          style: {
-            marginHorizontal: 24,
-          },
-        }}
-      >
+      <Tabs>
         {tabs.map((tab, index) => {
-          const { name, component: TabComponent } = tab;
+          const isSelected = index === currentIndex;
 
           return (
-            <Tab.Screen
-              key={index}
-              name={name}
-              children={() => (
-                <TabWrapper>
-                  <TabComponent pokemon={pokemon} />
-                </TabWrapper>
-              )}
-              options={{
-                tabBarLabel: ({ focused }) => (
-                  <Text
-                    color={focused ? 'black' : 'grey'}
-                    bold={!!focused}
-                    numberOfLines={1}
-                    adjustsFontSizeToFit
-                  >
-                    {name}
-                  </Text>
-                ),
-              }}
-            />
+            <TabButton key={index} onPress={() => handleChangeTab(index)}>
+              <Text color={isSelected ? 'black' : 'grey'} bold={isSelected}>
+                {tab.name}
+              </Text>
+            </TabButton>
           );
         })}
-      </Tab.Navigator>
+
+        <SelectedIndicator style={selectedIndicatorStyle} />
+      </Tabs>
+
+      <Animated.ScrollView
+        ref={scrollViewRef}
+        onScroll={onScroll}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        snapToInterval={width}
+        decelerationRate="fast"
+        bounces={false}
+      >
+        {tabs.map(({ slide: Slide }, index) => (
+          <SlideWrapper key={index}>
+            <Slide pokemon={pokemon} />
+          </SlideWrapper>
+        ))}
+      </Animated.ScrollView>
     </Container>
   );
 };

--- a/mobile/src/pages/Pokemon/PokemonDetails/styles.ts
+++ b/mobile/src/pages/Pokemon/PokemonDetails/styles.ts
@@ -4,7 +4,9 @@ import Constants from 'expo-constants';
 
 import { HEADER_HEIGHT } from '../../../constants';
 
-const { height } = Dimensions.get('window');
+import { TAB_BUTTON_WIDTH } from '.';
+
+const { height, width } = Dimensions.get('window');
 
 export const Container = styled(Animated.View)`
   height: ${height - (Constants.statusBarHeight + HEADER_HEIGHT)}px;
@@ -14,8 +16,37 @@ export const Container = styled(Animated.View)`
   padding: 16px 0;
 `;
 
-export const TabWrapper = styled.View`
-  flex: 1;
-  background: ${({ theme }) => theme.colors.white};
-  padding: 32px 24px;
+export const Tabs = styled.View`
+  padding: 16px 0 24px;
+  margin: 0 24px;
+  border-bottom-width: 1px;
+  border-style: solid;
+  border-color: ${({ theme }) => theme.colors.lightGrey};
+  position: relative;
+
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-around;
+`;
+
+export const TabButton = styled.TouchableOpacity`
+  height: 24px;
+  width: ${TAB_BUTTON_WIDTH}px;
+
+  align-items: center;
+  justify-content: center;
+`;
+
+export const SelectedIndicator = styled(Animated.View)`
+  height: 2px;
+  width: ${TAB_BUTTON_WIDTH}px;
+  background: ${({ theme }) => theme.colors.blue};
+
+  position: absolute;
+  bottom: -1px;
+`;
+
+export const SlideWrapper = styled.View`
+  width: ${width}px;
+  padding: 24px;
 `;

--- a/mobile/src/pages/Pokemon/PokemonDetails/styles.ts
+++ b/mobile/src/pages/Pokemon/PokemonDetails/styles.ts
@@ -4,7 +4,7 @@ import Constants from 'expo-constants';
 
 import { HEADER_HEIGHT } from '../../../constants';
 
-import { TAB_BUTTON_WIDTH } from '.';
+import { TAB_BUTTON_WIDTH } from './tabs';
 
 const { height, width } = Dimensions.get('window');
 

--- a/mobile/src/pages/Pokemon/PokemonDetails/tabs.ts
+++ b/mobile/src/pages/Pokemon/PokemonDetails/tabs.ts
@@ -5,27 +5,15 @@ import BaseStats from './BaseStats';
 import Evolution from './Evolution';
 import Moves from './Moves';
 
-export type TabProps = {
+type SlideProps = {
   pokemon: Pokemon;
 };
 
 const tabs = [
-  {
-    name: 'About',
-    component: About,
-  },
-  {
-    name: 'Base Stats',
-    component: BaseStats,
-  },
-  {
-    name: 'Evolution',
-    component: Evolution,
-  },
-  {
-    name: 'Moves',
-    component: Moves,
-  },
+  { name: 'About', slide: About },
+  { name: 'Base Stats', slide: BaseStats },
+  { name: 'Evolution', slide: Evolution },
+  { name: 'Moves', slide: Moves },
 ];
 
-export default tabs;
+export { tabs, SlideProps };

--- a/mobile/src/pages/Pokemon/PokemonDetails/tabs.ts
+++ b/mobile/src/pages/Pokemon/PokemonDetails/tabs.ts
@@ -1,3 +1,5 @@
+import { Dimensions } from 'react-native';
+
 import { Pokemon } from '../../../types';
 
 import About from './About';
@@ -16,4 +18,7 @@ const tabs = [
   { name: 'Moves', slide: Moves },
 ];
 
-export { tabs, SlideProps };
+const { width } = Dimensions.get('window');
+const TAB_BUTTON_WIDTH = (width - 48) / 4;
+
+export { tabs, SlideProps, TAB_BUTTON_WIDTH };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,13 +1334,6 @@
     query-string "^6.13.6"
     react-is "^16.13.0"
 
-"@react-navigation/material-top-tabs@^5.3.10":
-  version "5.3.10"
-  resolved "https://registry.yarnpkg.com/@react-navigation/material-top-tabs/-/material-top-tabs-5.3.10.tgz#158b694e87bff2eb9577e8142415de8ac3547412"
-  integrity sha512-mmQYEBhcLp1DwvuD8+HiFtYPk5zP43272C/38iX2T8AblcwRdoJejuO/GUzQcEPrmZHjeAnA5GDaMiXQM4EXLQ==
-  dependencies:
-    color "^3.1.3"
-
 "@react-navigation/native@^5.0.9":
   version "5.8.10"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-5.8.10.tgz#3fe806abff9efb085bcf595212803dd05a1347ca"


### PR DESCRIPTION
This PR remove the library [material-top-tab-navigator](https://reactnavigation.org/docs/material-top-tab-navigator/) because it was losing the pan gesture offset when change between tabs. To resolve this it was created a top-tabs-navigator from scratch using ScrollView and Animated API.